### PR TITLE
主界面功能增强；移除 command 文本限制

### DIFF
--- a/PostNamazu/Actions/Command.cs
+++ b/PostNamazu/Actions/Command.cs
@@ -41,34 +41,7 @@ namespace PostNamazu.Actions
             if (command == "")
                 throw new Exception("指令为空");
 
-            // 去掉command中的所有换行符
-            command = command.Replace("\n", "").Replace("\r", "");
-
-            const int maxByteLength = 180;
-            string ignoredPortion = null;
-
-            // 检查command的Unicode字节长度是否超过180字节
-            if (Encoding.UTF8.GetByteCount(command) > maxByteLength)
-            {
-                byte[] bytes = Encoding.UTF8.GetBytes(command);
-                int maxBytes = maxByteLength;
-
-                // 确保不会截断一个Unicode字符
-                while (maxBytes > 0 && (bytes[maxBytes] & 0xC0) == 0x80)
-                {
-                    maxBytes--;
-                }
-
-                string truncatedCommand = Encoding.UTF8.GetString(bytes, 0, maxBytes);
-                ignoredPortion = Encoding.UTF8.GetString(bytes, maxBytes, bytes.Length - maxBytes);
-                command = truncatedCommand;
-            }
-
             PluginUI.Log(command);
-            if (!string.IsNullOrEmpty(ignoredPortion))
-            {
-                PluginUI.Log($"忽略文本：“{ignoredPortion}”，因为系统宏的限制在180个字节以内。");
-            }
 
             var assemblyLock = Memory.Executor.AssemblyLock;
 

--- a/PostNamazu/Controls/PostNamazuUi.Designer.cs
+++ b/PostNamazu/Controls/PostNamazuUi.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         public void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.CheckAutoStart = new System.Windows.Forms.CheckBox();
             this.ButtonStop = new System.Windows.Forms.Button();
             this.ButtonStart = new System.Windows.Forms.Button();
@@ -36,9 +37,11 @@
             this.mainGroupBox = new System.Windows.Forms.GroupBox();
             this.label1 = new System.Windows.Forms.Label();
             this.flowLayoutActions = new System.Windows.Forms.FlowLayoutPanel();
+            this.ButtonCopySelection = new System.Windows.Forms.Button();
             this.ButtonCopyProblematic = new System.Windows.Forms.Button();
             this.ButtonClearMessage = new System.Windows.Forms.Button();
             this.lstMessages = new System.Windows.Forms.ListBox();
+            this.logTip = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.TextPort)).BeginInit();
             this.mainGroupBox.SuspendLayout();
             this.flowLayoutActions.SuspendLayout();
@@ -103,6 +106,7 @@
             // 
             this.mainGroupBox.Controls.Add(this.CheckAutoStart);
             this.mainGroupBox.Controls.Add(this.flowLayoutActions);
+            this.mainGroupBox.Controls.Add(this.ButtonCopySelection);
             this.mainGroupBox.Controls.Add(this.ButtonCopyProblematic);
             this.mainGroupBox.Controls.Add(this.ButtonClearMessage);
             this.mainGroupBox.Controls.Add(this.lstMessages);
@@ -112,7 +116,7 @@
             this.mainGroupBox.Controls.Add(this.lbPort);
             this.mainGroupBox.Location = new System.Drawing.Point(26, 18);
             this.mainGroupBox.Name = "mainGroupBox";
-            this.mainGroupBox.Size = new System.Drawing.Size(764, 630);
+            this.mainGroupBox.Size = new System.Drawing.Size(1164, 630);
             this.mainGroupBox.TabIndex = 1;
             this.mainGroupBox.TabStop = false;
             this.mainGroupBox.Text = "鲶鱼精邮差";
@@ -133,24 +137,34 @@
             this.flowLayoutActions.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flowLayoutActions.Location = new System.Drawing.Point(19, 145);
             this.flowLayoutActions.Name = "flowLayoutActions";
-            this.flowLayoutActions.Size = new System.Drawing.Size(234, 385);
+            this.flowLayoutActions.Size = new System.Drawing.Size(234, 349);
             this.flowLayoutActions.TabIndex = 2;
+            // 
+            // ButtonCopySelection
+            // 
+            this.ButtonCopySelection.Location = new System.Drawing.Point(19, 492);
+            this.ButtonCopySelection.Name = "ButtonCopySelection";
+            this.ButtonCopySelection.Size = new System.Drawing.Size(234, 35);
+            this.ButtonCopySelection.TabIndex = 8;
+            this.ButtonCopySelection.Text = "复制所选日志";
+            this.ButtonCopySelection.UseVisualStyleBackColor = true;
+            this.ButtonCopySelection.Click += new System.EventHandler(this.cmdCopySelection_Click);
             // 
             // ButtonCopyProblematic
             // 
-            this.ButtonCopyProblematic.Location = new System.Drawing.Point(19, 536);
+            this.ButtonCopyProblematic.Location = new System.Drawing.Point(19, 533);
             this.ButtonCopyProblematic.Name = "ButtonCopyProblematic";
             this.ButtonCopyProblematic.Size = new System.Drawing.Size(234, 35);
             this.ButtonCopyProblematic.TabIndex = 7;
-            this.ButtonCopyProblematic.Text = "复制到剪贴板";
+            this.ButtonCopyProblematic.Text = "复制全部日志";
             this.ButtonCopyProblematic.UseVisualStyleBackColor = true;
             this.ButtonCopyProblematic.Click += new System.EventHandler(this.cmdCopyProblematic_Click);
             // 
             // ButtonClearMessage
             // 
-            this.ButtonClearMessage.Location = new System.Drawing.Point(21, 577);
+            this.ButtonClearMessage.Location = new System.Drawing.Point(19, 574);
             this.ButtonClearMessage.Name = "ButtonClearMessage";
-            this.ButtonClearMessage.Size = new System.Drawing.Size(232, 32);
+            this.ButtonClearMessage.Size = new System.Drawing.Size(234, 35);
             this.ButtonClearMessage.TabIndex = 6;
             this.ButtonClearMessage.Text = "清空日志";
             this.ButtonClearMessage.UseVisualStyleBackColor = true;
@@ -162,11 +176,20 @@
             this.lstMessages.ItemHeight = 24;
             this.lstMessages.Location = new System.Drawing.Point(259, 29);
             this.lstMessages.Name = "lstMessages";
-            this.lstMessages.Size = new System.Drawing.Size(485, 580);
+            this.lstMessages.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+            this.lstMessages.Size = new System.Drawing.Size(885, 580);
             this.lstMessages.TabIndex = 5;
             this.lstMessages.HorizontalScrollbar = true;
             this.lstMessages.HorizontalExtent = 0;
-
+            this.lstMessages.MouseMove += new System.Windows.Forms.MouseEventHandler(lstMessages_MouseMove);
+            // 
+            // logTip
+            // 
+            this.logTip.AutoPopDelay = 32767;
+            this.logTip.InitialDelay = 200;
+            this.logTip.ReshowDelay = 200;
+            this.logTip.ShowAlways = true;
+            this.logTip.UseAnimation = true;
             // 
             // PostNamazuUi
             // 
@@ -174,7 +197,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.mainGroupBox);
             this.Name = "PostNamazuUi";
-            this.Size = new System.Drawing.Size(816, 662);
+            this.Size = new System.Drawing.Size(1216, 662);
             ((System.ComponentModel.ISupportInitialize)(this.TextPort)).EndInit();
             this.mainGroupBox.ResumeLayout(false);
             this.mainGroupBox.PerformLayout();
@@ -192,9 +215,11 @@
         public System.Windows.Forms.NumericUpDown TextPort;
         public System.Windows.Forms.Label lbPort;
         public System.Windows.Forms.GroupBox mainGroupBox;
+        public System.Windows.Forms.Button ButtonCopySelection;
         public System.Windows.Forms.Button ButtonCopyProblematic;
         public System.Windows.Forms.Button ButtonClearMessage;
         public System.Windows.Forms.ListBox lstMessages;
+        private System.Windows.Forms.ToolTip logTip;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutActions;
         private System.Windows.Forms.Label label1;
     }

--- a/PostNamazu/PostNamazu.cs
+++ b/PostNamazu/PostNamazu.cs
@@ -136,9 +136,12 @@ namespace PostNamazu
 
         private void ServerStop(object sender = null, EventArgs e = null)
         {
-            _httpServer.Stop();
-            _httpServer.PostNamazuDelegate = null;
-            _httpServer.OnException -= OnException;
+            if (_httpServer != null)
+            {
+                _httpServer.Stop();
+                _httpServer.PostNamazuDelegate = null;
+                _httpServer.OnException -= OnException;
+            }
 
             PluginUI.ButtonStart.Enabled = true;
             PluginUI.ButtonStop.Enabled = false;


### PR DESCRIPTION
### 主界面
<img src="https://github.com/Natsukage/PostNamazu/assets/85232361/5e5aa732-1659-430c-b31e-7a1720da9b34" width="500">  

· 加宽日志 ListBox 以便浏览长文本；  
· 添加鼠标悬停时显示日志文本的 ToolTip 以便浏览含有换行的日志；  
· 修改 ListBox 的选中模式为多行模式（允许 Ctrl/Shift 选择范围）；  
· 添加 “复制选中日志” 按钮；  
· 添加快捷键 Ctrl + C 复制当前选中日志；  
· 修复了复制日志时结尾多出一个换行的问题；  
· 修复了 http 无法启用时偶尔（未知原因）造成 “启用” 和 “停止” 按钮同时设为 Enable，导致此时点击 “停止” 时抛出空引用异常的问题。  

### 文本指令
· 移除了 #48 对 command 增加的限制。  
聊天框直接输入文本都可以发送接近 1024 字符，限制字符数纯属毫无意义的自我阉割。  
目前使用了需要在 command 中添加换行的触发器的用户至少有几千人，如果增加这种限制只会让人自己去找无阉割版。