### PR TITLE
fix: 修复 ExecuteCommand 内存签名冲突，及一些小修改

### DIFF
--- a/PostNamazu/Actions/Command.cs
+++ b/PostNamazu/Actions/Command.cs
@@ -14,8 +14,8 @@ namespace PostNamazu.Actions
         public override void GetOffsets()
         {
             base.GetOffsets();
-            ProcessChatBoxPtr = SigScanner.ScanText("E8 ?? ?? ?? ?? FE 86 ?? ?? ?? ?? C7 86");
-            GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01");
+            ProcessChatBoxPtr = SigScanner.ScanText("E8 ?? ?? ?? ?? FE 86 ?? ?? ?? ?? C7 86", nameof(ProcessChatBoxPtr));
+            GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01", nameof(GetUiModulePtr));
         }
 
         /// <summary>

--- a/PostNamazu/Actions/Mark.cs
+++ b/PostNamazu/Actions/Mark.cs
@@ -19,9 +19,9 @@ namespace PostNamazu.Actions
             base.GetOffsets();
 
             //char __fastcall sub_1407A6A60(__int64 g_MarkingController, __int64 MarkType, __int64 ActorID)
-            MarkingFunc = base.SigScanner.ScanText("48 89 5C 24 10 48 89 6C 24 18 57 48 83 EC 20 8D 42");//正确
-            LocalMarkingFunc = base.SigScanner.ScanText("E8 ?? ?? ?? ?? 4C 8B C5 8B D7 48 8B CB E8");//正确
-            MarkingController = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 4C 8B 85",3);//正确
+            MarkingFunc = base.SigScanner.ScanText("48 89 5C 24 10 48 89 6C 24 18 57 48 83 EC 20 8D 42", nameof(MarkingFunc)); //正确
+            LocalMarkingFunc = base.SigScanner.ScanText("E8 ?? ?? ?? ?? 4C 8B C5 8B D7 48 8B CB E8", nameof(LocalMarkingFunc)); //正确
+            MarkingController = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 4C 8B 85", 3, nameof(MarkingController)); //正确
         }
         [Command("mark")]
         public void DoMarking(string command)

--- a/PostNamazu/Actions/NormalCommand.cs
+++ b/PostNamazu/Actions/NormalCommand.cs
@@ -14,8 +14,8 @@ namespace PostNamazu.Actions
         public override void GetOffsets()
         {
             base.GetOffsets();
-            ProcessChatBoxPtr = SigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9");
-            GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01");
+            ProcessChatBoxPtr = SigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9", nameof(ProcessChatBoxPtr));
+            GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01", nameof(GetUiModulePtr));
         }
 
         /// <summary>

--- a/PostNamazu/Actions/Preset.cs
+++ b/PostNamazu/Actions/Preset.cs
@@ -18,11 +18,11 @@ namespace PostNamazu.Actions
         public override void GetOffsets()
         {
             base.GetOffsets();
-            var GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01");
+            var GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01", "GetUiModulePtr");
             UIModulePtr = Memory.CallInjected64<IntPtr>(GetUiModulePtr, PostNamazu.FrameworkPtr);
 
-            var mapIDOffset = SigScanner.Read<UInt16>(SigScanner.ScanText("44 89 81 ? ? ? ? 0F B7 84 24") + 3);
-            MapIDPtr = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 0F B6 55 ?? 24") + mapIDOffset;
+            var mapIDOffset = SigScanner.Read<UInt16>(SigScanner.ScanText("44 89 81 ? ? ? ? 0F B7 84 24", "mapIDOffset") + 3);
+            MapIDPtr = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 0F B6 55 ?? 24", 3, nameof(MapIDPtr)) + mapIDOffset;
         }
 
         private void GetWayMarkSlotOffset()

--- a/PostNamazu/Actions/WayMark.cs
+++ b/PostNamazu/Actions/WayMark.cs
@@ -22,10 +22,17 @@ namespace PostNamazu.Actions
         public override void GetOffsets()
         {
             base.GetOffsets();
-            MarkingController = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 4C 8B 85", 3);
+            MarkingController = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 4C 8B 85", 3, nameof(MarkingController));
             // 41 D1 C0 88 81 ? ? ? ? 8B 42 04 
             Waymarks = MarkingController + 0x1E0;
-            ExecuteCommandPtr = SigScanner.ScanText("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 8B E9 41 8B D9 48 8B 0D ?? ?? ?? ?? 41 8B F8 8B F2");
+            try
+            {
+                ExecuteCommandPtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 48 83 C4 ?? C3 CC CC CC CC CC CC CC CC CC CC CC CC 48 83 EC ?? 45 0F B6 C0", nameof(ExecuteCommandPtr));
+            }
+            catch 
+            {   // 可能和其他插件冲突，加一个备用
+                //ExecuteCommandPtr = SigScanner.ScanText("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 8B E9 41 8B D9 48 8B 0D ?? ?? ?? ?? 41 8B F8 8B F2", nameof(ExecuteCommandPtr));
+            }
         }
 
         /// <summary>

--- a/PostNamazu/Common/I18n.cs
+++ b/PostNamazu/Common/I18n.cs
@@ -40,10 +40,12 @@ namespace PostNamazu.Common
             ["ImportWaymarksForm/Local"] = "Waymarks applied locally.",
             ["ImportWaymarksForm/Public"] = "Waymarks have been made public.",
             ["NamazuModule/EmptyCommand"] = "Empty command.",
+            ["NamazuModule/GetOffsetsFail"] = "Failed to initialize the module {0}: \n{1}",
             ["NamazuModule/XivProcNotFound"] = "FFXIV process not found.",
             ["PostNamazu"] = "PostNamazu",
             ["PostNamazu/ActionIgnored"] = "Action Ignored: {0}: {1}",
             ["PostNamazu/ActionNotFound"] = "Unsupported operation: {0}",
+            ["PostNamazu/DoActionFail"] = "Exception when executing action {0}: \n{1}",
             ["PostNamazu/HttpException"] = "Unable to start listening on HTTP port {0}: \n{1}",
             ["PostNamazu/HttpStart"] = "Started HTTP listening on port {0}.",
             ["PostNamazu/HttpStop"] = "HTTP listening stopped.",
@@ -69,6 +71,9 @@ namespace PostNamazu.Common
             ["PostNamazuUi/CfgReset"] = "Configuration has been reset.",
             ["PostNamazuUi/ExportWaymarks"] = "Waymarker text has been copied to the clipboard.",
             ["PostNamazuUi/ExportWaymarksFail"] = "Failed to read existing waymarkers:\n{0}",
+            ["SigScanner/ResultMultiple"] = "Scanned{0} and found {1} memory signatures, unable to determine a unique location.",
+            ["SigScanner/ResultNone"] = "Scanned{0} and did not find the required memory signatures.",
+
         };
 
         public static string Translate(string key, string CN, params object[] args)

--- a/PostNamazu/Common/I18n.cs
+++ b/PostNamazu/Common/I18n.cs
@@ -28,6 +28,7 @@ namespace PostNamazu.Common
             ["grpLang"]                         = new() { [Language.EN] = "Language",                   [Language.CN] = "语言" },
             ["grpWaymarks"]                     = new() { [Language.EN] = "Waymarks",                   [Language.CN] = "场地标点" },
             ["ImportWaymarksForm"]              = new() { [Language.EN] = "Import waymarks",            [Language.CN] = "导入场地标点" },
+            ["ImportWaymarksForm/btnDefault"]   = new() { [Language.EN] = "Fill in default data",       [Language.CN] = "填入默认数据" },
             ["ImportWaymarksForm/btnPlace"]     = new() { [Language.EN] = "Import as local waymarks",   [Language.CN] = "导入为本地标点" },
             ["ImportWaymarksForm/btnPublic"]    = new() { [Language.EN] = "Import as public waymarks",  [Language.CN] = "导入为公开标点" },
             ["ImportWaymarksForm/grpMain"]      = new() { [Language.EN] = "Input waymarks JSON string", [Language.CN] = "输入标点 JSON 字符串" },

--- a/PostNamazu/Common/NamazuModule.cs
+++ b/PostNamazu/Common/NamazuModule.cs
@@ -29,7 +29,7 @@ namespace PostNamazu.Actions
                 isReady = FFXIV_ACT_Plugin != null && FFXIV != null && Memory != null;
             }
             catch (Exception ex) {
-                Log(ex.ToString());
+                Log(I18n.Translate("NamazuModule/GetOffsetsFail", "初始化 {0} 模组失败：\n{1}", GetType().Name, ex.Message + " \n" + ex.StackTrace));
                 isReady = false;
             }
             //Log("初始化完成");

--- a/PostNamazu/Common/SigScanner.cs
+++ b/PostNamazu/Common/SigScanner.cs
@@ -376,19 +376,49 @@ namespace PostNamazu.Common
         }
 
 
-        public T ScanText<T>(string pattern, Func<IntPtr, T> visitor) {
+        public T ScanText<T>(string pattern, Func<IntPtr, T> visitor, string name = null)
+        {
             var results = FindPattern(pattern);
             if (results.Count > 1)
-                throw new ArgumentException($"Provided pattern found {results.Count}, only a single result is acceptable");
-
+            {
+                throw new ArgumentException(I18n.Translate(
+                    "SigScanner/ResultMultiple",
+                    "扫描{0}时匹配到 {1} 处内存签名，无法确定唯一位置。",
+                    name == null ? "" : $" {name} ",
+                    results.Count
+                ));
+            }
+            if (results.Count == 0)
+            {
+                throw new ArgumentException(I18n.Translate(
+                    "SigScanner/ResultNone",
+                    "扫描{0}时未匹配到所需的内存签名。",
+                    name == null ? "" : $" {name} "
+                ));
+            }
             return visitor(results[0]);
         }
 
-        public IntPtr ScanText(string pattern) {
+        public IntPtr ScanText(string pattern, string name = null)
+        {
             var results = FindPattern(pattern);
             if (results.Count > 1)
-                throw new ArgumentException($"Provided pattern found {results.Count}, only a single result is acceptable");
-
+            {
+                throw new ArgumentException(I18n.Translate(
+                    "SigScanner/ResultMultiple", 
+                    "扫描{0}时匹配到 {1} 处内存签名，无法确定唯一位置。", 
+                    name == null ? "" : $" {name} ",
+                    results.Count
+                ));
+            }
+            if (results.Count == 0)
+            {
+                throw new ArgumentException(I18n.Translate(
+                    "SigScanner/ResultNone", 
+                    "扫描{0}时未匹配到所需的内存签名。", 
+                    name == null ? "" : $" {name} "
+                ));
+            }
             var scanRet = results[0];
             var insnByte = ReadByte(scanRet);
             if (insnByte == 0xE8 || insnByte == 0xE9)
@@ -467,8 +497,8 @@ namespace PostNamazu.Common
         /// <param name="signature">The signature of the function using the data.</param>
         /// <param name="offset">The offset from function start of the instruction using the data.</param>
         /// <returns>An IntPtr to the static memory location.</returns>
-        public IntPtr GetStaticAddressFromSig(string signature, int offset = 0) {
-            IntPtr instrAddr = ScanText(signature);
+        public IntPtr GetStaticAddressFromSig(string signature, int offset = 0, string name = null) {
+            IntPtr instrAddr = ScanText(signature, name);
             instrAddr = IntPtr.Add(instrAddr, offset);
             long bAddr = (long)_baseAddress;
             long num;

--- a/PostNamazu/Forms/ImportWaymarksForm.cs
+++ b/PostNamazu/Forms/ImportWaymarksForm.cs
@@ -28,6 +28,7 @@ namespace PostNamazu
         private GroupBox grpMain;
         private TableLayoutPanel mainTable;
         public TextBox TxtWaymarksData;
+        public Button btnDefault;
         public Button btnPlace;
         public Button btnPublic;
 
@@ -55,6 +56,8 @@ namespace PostNamazu
             }
             TxtWaymarksData.Select(TxtWaymarksData.TextLength, 0);
 
+            btnDefault = MyButton(nameof(btnDefault));
+            btnDefault.Click += new EventHandler(btnDefault_Click);
             btnPlace = MyButton(nameof(btnPlace));
             btnPlace.Click += new EventHandler(btnPlace_Click);
             btnPublic = MyButton(nameof(btnPublic));
@@ -67,13 +70,15 @@ namespace PostNamazu
             mainTable.RowCount = 2;
             mainTable.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
             mainTable.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            mainTable.ColumnCount = 2;
-            mainTable.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
-            mainTable.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+            mainTable.ColumnCount = 3;
+            mainTable.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33));
+            mainTable.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33));
+            mainTable.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33));
             mainTable.Controls.Add(TxtWaymarksData, 0, 0);
-            mainTable.SetColumnSpan(TxtWaymarksData, 2);
-            mainTable.Controls.Add(btnPlace, 0, 1);
-            mainTable.Controls.Add(btnPublic, 1, 1);
+            mainTable.SetColumnSpan(TxtWaymarksData, 3);
+            mainTable.Controls.Add(btnDefault, 0, 1);
+            mainTable.Controls.Add(btnPlace, 1, 1);
+            mainTable.Controls.Add(btnPublic, 2, 1);
 
             this.FormClosed += (_, __) =>
             {
@@ -100,6 +105,11 @@ namespace PostNamazu
             };
             btn.Text = I18n.TranslateUi($"ImportWaymarksForm/{btn.Name}");
             return btn;
+        }
+
+        private void btnDefault_Click(object sender, EventArgs e)
+        {
+            TxtWaymarksData.Text = _defaultData;
         }
 
         private void btnPlace_Click(object sender, EventArgs e)

--- a/PostNamazu/PostNamazu.cs
+++ b/PostNamazu/PostNamazu.cs
@@ -1,16 +1,17 @@
-﻿﻿using System;
+﻿using Advanced_Combat_Tracker;
+using GreyMagic;
+using PostNamazu.Actions;
+using PostNamazu.Attributes;
+using PostNamazu.Common;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
-using PostNamazu.Actions;
-using PostNamazu.Attributes;
-using PostNamazu.Common;
-using Advanced_Combat_Tracker;
-using GreyMagic;
 
 namespace PostNamazu
 {
@@ -70,6 +71,8 @@ namespace PostNamazu
             InitializeActions();
             TriggIntegration();
             OverlayIntegration();
+
+            Assembly.Load("GreyMagic"); // 直接加载而非首次调用时延迟加载，防止没开启游戏而没调用 GreyMagic 初始化 Memory 时其他插件找不到 GreyMagic
 
             _lblStatus.Text = I18n.Translate("PostNamazu/PluginInit", "鲶鱼精邮差已启动。");
         }
@@ -242,7 +245,7 @@ namespace PostNamazu
                 _entrancePtr = SigScanner.ScanText("4C 8B DC 56 41 57 48 81 EC ? ? ? ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 84 24 ? ? ? ? 48 83 B9 ? ? ? ? ? 4C 8B FA"); //7.0
                 return true;
             }
-            catch (ArgumentOutOfRangeException) {
+            catch (ArgumentException) {
                 //PluginUI.Log(I18n.Translate("PostNamazu/XivProcInjectFail", "无法注入当前进程，可能是已经被其他进程注入了，请尝试重启游戏。"));
             }
 
@@ -250,7 +253,7 @@ namespace PostNamazu
                 _entrancePtr = SigScanner.ScanText("E9 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 83 B9");
                 return true;
             }
-            catch (ArgumentOutOfRangeException) {
+            catch (ArgumentException) {
                 PluginUI.Log(I18n.Translate("PostNamazu/XivProcInjectFail", "无法注入当前进程，可能是已经被其他进程注入了，请尝试重启游戏。"));
             }
             return false;
@@ -489,7 +492,7 @@ namespace PostNamazu
             catch (NamazuModule.IgnoredException) { }
             catch (Exception ex)
             {
-                PluginUI.Log(ex.ToString());
+                PluginUI.Log(I18n.Translate("PostNamazu/DoActionFail", "执行 {0} 动作时遇到错误：{1}", command, ex.Message + "\n" + ex.StackTrace));
             }
         }
 


### PR DESCRIPTION
· 有人反馈 ExecuteCommand 这个内存签名和卫月冲突导致扫描不到 sig，无法注入进程，加了一个备用 sig，应该没问题了

· 扫不到 sig 的时候明确提示出错的模组等信息

· 初始化时立刻加载 GreyMagic 而非延迟加载，防止没开启游戏而没调用 GreyMagic 初始化 Memory 时，其他插件找不到 GreyMagic

· 导入标点窗口添加一个按钮还原默认数据 ，防止错误数据在关闭窗口时保存且无法复原默认文本

麻烦咯