### PR TITLE
fix: 修复Mark方法无法对0xE000000和0xE0000000进行标记的问题

### DIFF
--- a/PostNamazu/Actions/Mark.cs
+++ b/PostNamazu/Actions/Mark.cs
@@ -37,6 +37,14 @@ namespace PostNamazu.Actions
 
         private FFXIV_ACT_Plugin.Common.Models.Combatant GetActor(uint? id, string name)
         {
+            if (id is (0xE0000000 or 0xE000000))
+            {
+                FFXIV_ACT_Plugin.Common.Models.Combatant actor = new()
+                {
+                    ID = 0xE0000000
+                };
+                return actor;
+            }
             var combatants = FFXIV_ACT_Plugin.DataRepository.GetCombatantList().Where(i => !string.IsNullOrEmpty(i.Name) && i.ID != 0xE0000000);
             return combatants.FirstOrDefault(i => i.ID == id) 
                 ?? combatants.FirstOrDefault(i => i.Name == name)


### PR DESCRIPTION
当前版本标记0xE000000时会出现以下错误信息 
```
执行 mark 动作时遇到错误：未能找到实体： E0000000
   在 PostNamazu.Actions.Mark.GetActor(Nullable`1 id, String name)
   在 PostNamazu.Actions.Mark.DoMarking(String command)
   在 PostNamazu.PostNamazu.DoAction(String command, String payload)
```

- 最后一个能正常使用的版本应该是1.3.4.0
- 使用国际服测试，**国服未测试**