### PR TITLE
1.3.5.4+

### DIFF
--- a/PostNamazu/Actions/Command.cs
+++ b/PostNamazu/Actions/Command.cs
@@ -1,5 +1,4 @@
-using PostNamazu.Attributes;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -17,8 +16,8 @@ namespace PostNamazu.Actions
         public override void GetOffsets()
         {
             base.GetOffsets();
-            ProcessChatBoxPtr = SigScanner.ScanText("E8 ?? ?? ?? ?? FE 86 ?? ?? ?? ?? C7 86", nameof(ProcessChatBoxPtr));
-            GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01", nameof(GetUiModulePtr));
+            ProcessChatBoxPtr = SigScanner.ScanText("E8 * * * * FE 86 ? ? ? ? C7 86", nameof(ProcessChatBoxPtr));
+            GetUiModulePtr = SigScanner.ScanText("E8 * * * * 80 7B 1D 01", nameof(GetUiModulePtr));
         }
 
         const string CurrentChannelPrefix = "/current ";
@@ -63,7 +62,7 @@ namespace PostNamazu.Actions
                 var raptureModule = Memory.CallInjected64<IntPtr>(Memory.Read<IntPtr>(Memory.Read<IntPtr>(uiModulePtr) + (0x8 * 9)), uiModulePtr);
                 _ = Memory.CallInjected64<int>(ProcessChatBoxPtr, raptureModule, allocatedMemory.Address, uiModulePtr);
             });
-            }
+        }
 
         protected override Dictionary<string, Dictionary<Language, string>> LocalizedStrings { get; } = new()
         {

--- a/PostNamazu/Actions/Command.cs
+++ b/PostNamazu/Actions/Command.cs
@@ -45,11 +45,8 @@ namespace PostNamazu.Actions
             CheckChannel(ref command);
             PluginUI.Log(command);
 
-            var assemblyLock = Memory.Executor.AssemblyLock;
-
-            var flag = false;
-            try {
-                Monitor.Enter(assemblyLock, ref flag);
+            ExecuteWithLock(() =>
+            {
                 var array = Encoding.UTF8.GetBytes(command);
                 using AllocatedMemory allocatedMemory = Memory.CreateAllocatedMemory(400), allocatedMemory2 = Memory.CreateAllocatedMemory(array.Length + 30);
                 allocatedMemory2.AllocateOfChunk("cmd", array.Length);
@@ -65,6 +62,7 @@ namespace PostNamazu.Actions
                 var uiModulePtr = Memory.CallInjected64<IntPtr>(GetUiModulePtr, PostNamazu.FrameworkPtr);
                 var raptureModule = Memory.CallInjected64<IntPtr>(Memory.Read<IntPtr>(Memory.Read<IntPtr>(uiModulePtr) + (0x8 * 9)), uiModulePtr);
                 _ = Memory.CallInjected64<int>(ProcessChatBoxPtr, raptureModule, allocatedMemory.Address, uiModulePtr);
+            });
             }
 
         protected override Dictionary<string, Dictionary<Language, string>> LocalizedStrings { get; } = new()

--- a/PostNamazu/Actions/Mark.cs
+++ b/PostNamazu/Actions/Mark.cs
@@ -65,18 +65,12 @@ namespace PostNamazu.Actions
             {
                 PluginUI.Log($"Mark: Actor={actor.Name} (0x{actor.ID:X8}), Type={markingType} ({(int)markingType}), LocalOnly={localOnly}");
             }
-            var assemblyLock = Memory.Executor.AssemblyLock;
-            var flag = false;
-            try
+            ExecuteWithLock(() =>
             {
-                Monitor.Enter(assemblyLock, ref flag);
                 _ = !localOnly
                     ? Memory.CallInjected64<char>(MarkingFunc, MarkingController, markingType, actor.ID) 
                     : Memory.CallInjected64<char>(LocalMarkingFunc, MarkingController, markingType - 1, actor.ID, 0); //本地标点的markingType从0开始，因此需要-1
-            }
-            finally {
-                if (flag) Monitor.Exit(assemblyLock);
-            }
+            });
         }
 
         protected override Dictionary<string, Dictionary<Language, string>> LocalizedStrings { get; } = new()

--- a/PostNamazu/Actions/Mark.cs
+++ b/PostNamazu/Actions/Mark.cs
@@ -21,15 +21,16 @@ namespace PostNamazu.Actions
             //char __fastcall sub_1407A6A60(__int64 g_MarkingController, __int64 MarkType, __int64 ActorID)
             try
             {
-                MarkingFunc = SigScanner.ScanText("E8 ?? ?? ?? ?? 84 C0 74 ?? 48 8B 06 48 8B CE FF 50 ?? 48 8B C8 BA ?? ?? ?? ?? E8 ?? ?? ?? ?? 33 C0 E9", nameof(MarkingFunc));
+                MarkingFunc = SigScanner.ScanText("E8 * * * * 84 C0 74 ? 48 8B 06 48 8B CE FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? 33 C0 E9", nameof(MarkingFunc));
             }
             catch
             {
                 MarkingFunc = SigScanner.ScanText("48 89 5C 24 10 48 89 6C 24 18 57 48 83 EC 20 8D 42", nameof(MarkingFunc));
             }
-            LocalMarkingFunc = SigScanner.ScanText("E8 ?? ?? ?? ?? 4C 8B C5 8B D7 48 8B CB E8", nameof(LocalMarkingFunc)); //正确
-            MarkingController = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 4C 8B 85", 3, nameof(MarkingController)); //正确
+            LocalMarkingFunc = SigScanner.ScanText("E8 * * * * 4C 8B C5 8B D7 48 8B CB E8", nameof(LocalMarkingFunc)); //正确
+            MarkingController = SigScanner.ScanText("48 8D 0D * * * * 4C 8B 85", nameof(MarkingController)); //正确
         }
+
         [Command("mark")]
         public void DoMarking(string command)
         {
@@ -68,7 +69,7 @@ namespace PostNamazu.Actions
             ExecuteWithLock(() =>
             {
                 _ = !localOnly
-                    ? Memory.CallInjected64<char>(MarkingFunc, MarkingController, markingType, actor.ID) 
+                    ? Memory.CallInjected64<char>(MarkingFunc, MarkingController, markingType, actor.ID)
                     : Memory.CallInjected64<char>(LocalMarkingFunc, MarkingController, markingType - 1, actor.ID, 0); //本地标点的markingType从0开始，因此需要-1
             });
         }

--- a/PostNamazu/Actions/NormalCommand.cs
+++ b/PostNamazu/Actions/NormalCommand.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using PostNamazu.Attributes;
+using static PostNamazu.Common.I18n;
 using GreyMagic;
 
 namespace PostNamazu.Actions
@@ -21,6 +23,18 @@ namespace PostNamazu.Actions
                 ProcessChatBoxPtr = SigScanner.ScanText("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F2 48 8B F9 45 84 C9", nameof(ProcessChatBoxPtr));
             }
             GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01", nameof(GetUiModulePtr));
+
+        const string CurrentChannelPrefix = "/current ";
+        void CheckChannel(ref string command)
+        {
+            if (!command.StartsWith("/"))
+            {
+                throw new ArgumentException(GetLocalizedString("NoChannelError"));
+            }
+            if (command.StartsWith(CurrentChannelPrefix))
+            {
+                command = command.Substring(CurrentChannelPrefix.Length);
+            }
         }
 
         /// <summary>
@@ -31,7 +45,7 @@ namespace PostNamazu.Actions
         public void DoNormalTextCommand(string command)
         {
             CheckBeforeExecution(command);
-
+            CheckChannel(ref command);
             PluginUI.Log(command);
 
             var assemblyLock = Memory.Executor.AssemblyLock;
@@ -58,5 +72,14 @@ namespace PostNamazu.Actions
                 if (flag) Monitor.Exit(assemblyLock);
             }
         }
+
+        protected override Dictionary<string, Dictionary<Language, string>> LocalizedStrings { get; } = new()
+        {
+            ["NoChannelError"] = new()
+            {
+                [Language.EN] = $"To avoid sending wrong text to public channels, only commands starting with \"/\" are permitted. Add the prefix \"{CurrentChannelPrefix}\" to post to the current channel.",
+                [Language.CN] = $"为防止误操作导致错误文本发送至公共频道，仅允许以 \"/\" 开头的指令。如需发送至当前频道，请加前缀 \"{CurrentChannelPrefix}\"。"
+            },
+        };
     }
 }

--- a/PostNamazu/Actions/NormalCommand.cs
+++ b/PostNamazu/Actions/NormalCommand.cs
@@ -48,11 +48,8 @@ namespace PostNamazu.Actions
             CheckChannel(ref command);
             PluginUI.Log(command);
 
-            var assemblyLock = Memory.Executor.AssemblyLock;
-
-            var flag = false;
-            try {
-                Monitor.Enter(assemblyLock, ref flag);
+            ExecuteWithLock(() =>
+            {
                 var array = Encoding.UTF8.GetBytes(command);
                 using AllocatedMemory allocatedMemory = Memory.CreateAllocatedMemory(400), allocatedMemory2 = Memory.CreateAllocatedMemory(array.Length + 30);
                 allocatedMemory2.AllocateOfChunk("cmd", array.Length);
@@ -66,11 +63,8 @@ namespace PostNamazu.Actions
                 allocatedMemory.Write("tLength", array.Length + 1);
                 allocatedMemory.Write("t3", 0x00);
                 var uiModulePtr = Memory.CallInjected64<IntPtr>(GetUiModulePtr, PostNamazu.FrameworkPtr);
-                _ = Memory.CallInjected64<int>(ProcessChatBoxPtr, uiModulePtr,allocatedMemory.Address, IntPtr.Zero, (byte)0);
-            }
-            finally {
-                if (flag) Monitor.Exit(assemblyLock);
-            }
+                _ = Memory.CallInjected64<int>(ProcessChatBoxPtr, uiModulePtr, allocatedMemory.Address, IntPtr.Zero, (byte)0);
+            });
         }
 
         protected override Dictionary<string, Dictionary<Language, string>> LocalizedStrings { get; } = new()

--- a/PostNamazu/Actions/NormalCommand.cs
+++ b/PostNamazu/Actions/NormalCommand.cs
@@ -16,13 +16,16 @@ namespace PostNamazu.Actions
         public override void GetOffsets()
         {
             base.GetOffsets();
-            try
+            try // 7.1
+            {
+                ProcessChatBoxPtr = SigScanner.ScanText("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F2 48 8B F9 45 84 C9");
+            }
+            catch // 7.0
             {
                 ProcessChatBoxPtr = SigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9", nameof(ProcessChatBoxPtr));
-            }catch {
-                ProcessChatBoxPtr = SigScanner.ScanText("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F2 48 8B F9 45 84 C9", nameof(ProcessChatBoxPtr));
             }
-            GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01", nameof(GetUiModulePtr));
+            GetUiModulePtr = SigScanner.ScanText("E8 * * * * 80 7B 1D 01", nameof(GetUiModulePtr));
+        }
 
         const string CurrentChannelPrefix = "/current ";
         void CheckChannel(ref string command)

--- a/PostNamazu/Actions/Preset.cs
+++ b/PostNamazu/Actions/Preset.cs
@@ -18,11 +18,11 @@ namespace PostNamazu.Actions
         public override void GetOffsets()
         {
             base.GetOffsets();
-            var GetUiModulePtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 80 7B 1D 01", "GetUiModulePtr");
+            var GetUiModulePtr = SigScanner.ScanText("E8 * * * * 80 7B 1D 01", "GetUiModulePtr");
             UIModulePtr = Memory.CallInjected64<IntPtr>(GetUiModulePtr, PostNamazu.FrameworkPtr);
 
             var mapIDOffset = SigScanner.Read<UInt16>(SigScanner.ScanText("44 89 81 ? ? ? ? 0F B7 84 24", "mapIDOffset") + 3);
-            MapIDPtr = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 0F B6 55 ?? 24", 3, nameof(MapIDPtr)) + mapIDOffset;
+            MapIDPtr = SigScanner.ScanText("48 8D 0D * * * * 0F B6 55 ?? 24", nameof(MapIDPtr)) + mapIDOffset;
         }
 
         private void GetWayMarkSlotOffset()

--- a/PostNamazu/Actions/WayMark.cs
+++ b/PostNamazu/Actions/WayMark.cs
@@ -201,11 +201,8 @@ namespace PostNamazu.Actions
         /// <param name="waymarks">标点，传入 null 时清空标点，单个标点为 null 时忽略。</param>
         public void Public(WayMarks waymarks)
         {
-            var assemblyLock = Memory.Executor.AssemblyLock;
-            var flag = false;
-            try
+            ExecuteWithLock(() => 
             {
-                Monitor.Enter(assemblyLock, ref flag);
                 if (waymarks == null || waymarks.All(waymark => waymark?.Active == false)) 
                 {   // clear all
                     Memory.CallInjected64<IntPtr>(ExecuteCommandPtr, 313, 0, 0, 0, 0);
@@ -230,12 +227,8 @@ namespace PostNamazu.Actions
                             Memory.CallInjected64<IntPtr>(ExecuteCommandPtr, 318, idx, 0, 0, 0);
                         }
                     }
-                }
             }
-            finally
-            {
-                if (flag) Monitor.Exit(assemblyLock);
-            }
+            });
         }
 
         public bool GetInCombat()

--- a/PostNamazu/Actions/WayMark.cs
+++ b/PostNamazu/Actions/WayMark.cs
@@ -22,12 +22,11 @@ namespace PostNamazu.Actions
         public override void GetOffsets()
         {
             base.GetOffsets();
-            MarkingController = SigScanner.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 4C 8B 85", 3, nameof(MarkingController));
-            // 41 D1 C0 88 81 ? ? ? ? 8B 42 04 
+            MarkingController = SigScanner.ScanText("48 8D 0D * * * * 4C 8B 85", nameof(MarkingController));
             Waymarks = MarkingController + 0x1E0;
             try
             {
-                ExecuteCommandPtr = SigScanner.ScanText("E8 ?? ?? ?? ?? 48 83 C4 ?? C3 CC CC CC CC CC CC CC CC CC CC CC CC 48 83 EC ?? 45 0F B6 C0", nameof(ExecuteCommandPtr));
+                ExecuteCommandPtr = SigScanner.ScanText("E8 * * * * 48 83 C4 ?? C3 CC CC CC CC CC CC CC CC CC CC CC CC 48 83 EC ?? 45 0F B6 C0", nameof(ExecuteCommandPtr));
             }
             catch 
             {   // 可能和其他插件冲突，加一个备用
@@ -203,7 +202,7 @@ namespace PostNamazu.Actions
         {
             ExecuteWithLock(() => 
             {
-                if (waymarks == null || waymarks.All(waymark => waymark?.Active == false)) 
+                if (waymarks == null || waymarks.All(waymark => waymark?.Active == false))
                 {   // clear all
                     Memory.CallInjected64<IntPtr>(ExecuteCommandPtr, 313, 0, 0, 0, 0);
                     if (waymarks == null)
@@ -227,7 +226,7 @@ namespace PostNamazu.Actions
                             Memory.CallInjected64<IntPtr>(ExecuteCommandPtr, 318, idx, 0, 0, 0);
                         }
                     }
-            }
+                }
             });
         }
 

--- a/PostNamazu/Common/I18n.cs
+++ b/PostNamazu/Common/I18n.cs
@@ -66,7 +66,7 @@ namespace PostNamazu.Common
             ["PostNamazu/XivDetectMemRegionGlobal"] = "Set region to global server (detected by memory).",
             ["PostNamazu/XivDetectRegionCN"] = "Set region to Chinese server (detected by player name).",
             ["PostNamazu/XivDetectRegionGlobal"] = "Set region to global server (detected by player name).",
-            ["PostNamazu/XivFrameworkNotFound"] = "Failed to find memory signature for Framework, some features will not be available. The plugin may need to be updated.",
+            ["PostNamazu/XivFrameworkNotFound"] = "Failed to find memory signature for Framework, some features will not be available. The plugin may need to be updated. Exception: {0}",
             ["PostNamazu/XivProcInject"] = "Found FFXIV process {0}.",
             ["PostNamazu/XivProcInjectException"] = "Error when injecting into FFXIV process, retry later: \n{0}",
             ["PostNamazu/XivProcInjectFail"] = "Unable to inject into the current FFXIV process, it may have already been injected by another process. Please try restarting the game.",
@@ -75,6 +75,7 @@ namespace PostNamazu.Common
             ["PostNamazuUi/CfgReset"] = "Configuration has been reset.",
             ["PostNamazuUi/ExportWaymarks"] = "Waymarker text has been copied to the clipboard.",
             ["PostNamazuUi/ExportWaymarksFail"] = "Failed to read existing waymarkers:\n{0}",
+            ["SigScanner/RelAddressingFormatError"] = "Relative addressing sigcode ({0}) must contain exactly 4 consecutive stars (* * * *) and no additional * elsewhere.",
             ["SigScanner/ResultMultiple"] = "Scanned{0} and found {1} memory signatures, unable to determine a unique location.",
             ["SigScanner/ResultNone"] = "Scanned{0} and did not find the required memory signatures.",
 

--- a/PostNamazu/Common/NamazuModule.cs
+++ b/PostNamazu/Common/NamazuModule.cs
@@ -4,6 +4,7 @@ using PostNamazu.Common;
 using GreyMagic;
 using System.Collections.Generic;
 using static PostNamazu.Common.I18n;
+using System.Threading;
 
 namespace PostNamazu.Actions
 {
@@ -127,6 +128,34 @@ namespace PostNamazu.Actions
 
         internal class IgnoredException : Exception {
             internal IgnoredException(string msg) : base(msg) { }
+        }
+
+        public static void ExecuteWithLock(Action action)
+        {
+            bool lockTaken = false;
+            try
+            {
+                Monitor.Enter(Memory.Executor.AssemblyLock, ref lockTaken);
+                action();
+            }
+            finally 
+            { 
+                if (lockTaken) Monitor.Exit(Memory.Executor.AssemblyLock); 
+            }
+        }
+
+        public static T ExecuteWithLock<T>(Func<T> function)
+        {
+            bool lockTaken = false;
+            try
+            {
+                Monitor.Enter(Memory.Executor.AssemblyLock, ref lockTaken);
+                return function();
+            }
+            finally 
+            { 
+                if (lockTaken) Monitor.Exit(Memory.Executor.AssemblyLock); 
+            }
         }
     }
 

--- a/PostNamazu/PostNamazu.cs
+++ b/PostNamazu/PostNamazu.cs
@@ -277,7 +277,7 @@ namespace PostNamazu
             }
 
             try {
-                _entrancePtr = SigScanner.ScanText("E9 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 83 B9");
+                _entrancePtr = SigScanner.ScanText("E9 * * * * 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 83 B9");
                 return true;
             }
             catch (ArgumentException) {
@@ -367,37 +367,27 @@ namespace PostNamazu
         {             
             get
             {
-                if (_frameworkPtrPtr == IntPtr.Zero)
-                {
-                    IntPtr sigStart; int offset;
-                    try
-                    {   // 7.0 CN
-                        sigStart = SigScanner.ScanText("49 8B C4 48 8B 0D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ??");
-                        offset = 20;
-                    }
-                    catch 
-                    {
-                        try
-                        {   // 7.0 global
-                            sigStart = SigScanner.ScanText("49 8B DC 48 89 1D ?? ?? ?? ??");
-                            offset = 6;
-                        }
-                        catch
-                        {
-                            PluginUI.Log(I18n.Translate("PostNamazu/XivFrameworkNotFound", "未找到 Framework 的内存签名，部分功能无法使用，可能需要更新插件版本。"));
-                            return IntPtr.Zero;
-                        }
-                    }
-                    try
-                    {
-                        _frameworkPtrPtr = sigStart + (offset + 4) + Memory.Read<int>(sigStart + offset);
-                    }
-                    catch
-                    { 
-                        throw new Exception(I18n.Translate("PostNamazu/ReadMemoryFail", "初始化时读取内存失败，可能是卫月等插件所致。"));
-                    }
+                if (_frameworkPtrPtr != IntPtr.Zero)
+                { 
+                    return _frameworkPtrPtr;
                 }
-                return _frameworkPtrPtr;
+                try // 7.0 CN
+                {
+                    _frameworkPtrPtr = SigScanner.ScanText("49 8B C4 48 8B 0D ? ? ? ? 48 8D 15 ? ? ? ? 48 89 05 * * * *", nameof(_frameworkPtrPtr));
+                    return _frameworkPtrPtr;
+                }
+                catch { }
+                try // 7.0 global
+                {
+                    _frameworkPtrPtr = SigScanner.ScanText("49 8B DC 48 89 1D * * * *", nameof(_frameworkPtrPtr));
+                    return _frameworkPtrPtr;
+                }
+                catch (Exception ex)
+                {
+                    PluginUI.Log(I18n.Translate("PostNamazu/XivFrameworkNotFound", 
+                        "未找到 Framework 的内存签名，部分功能无法使用，可能需要更新插件版本。错误：{0}", ex.Message));
+                    return IntPtr.Zero;
+                }
             }
         }
 


### PR DESCRIPTION
### [feat: Command/NormalCommand 仅接受 / 开头的文本指令](https://github.com/Natsukage/PostNamazu/commit/d8925abb530cba461e95d0841b2c76b9563f30f0)
防止误输入将文本发到公共频道
如果确实想发送至当前频道，在文本前添加 `/current` 前缀

> [!WARNING]
> 少数用户可能受此更改影响。

### [feat: 内存扫描 sigcode 语法改为明确指定相对寻址位置](https://github.com/Natsukage/PostNamazu/commit/a271e2f4345ee5b6197671ea07b77b5bb845003f)
适用于任意类型的相对寻址（相对寻址计算方式为 `* * * *` 后的地址 + 这四字节对应的 int 偏移量）

以免：
- `E8/E9 ? ? ? ?` 仅用于定位时却被强制跳转
- `48 x x ? ? ? ?` 之类的相对寻址依然需要手动指定 offset

`?` 或 `??` 表示普通通配符，如：
- `48 89 5C 24 ?? ...`

`*` 或 `**` 表示相对寻址通配符，如果使用，则仅能有连续四个，如：
- `48 8D 0D * * * * 4C 8B 85 ...`
- `E8 * * * * 48 83 C4 ? E9 ? ? ? ? ...`

> [!WARNING]
> 少数用户可能受此更改影响（如果从外部调用了鲶鱼精邮差的内存扫描）。

### [refactor: 将线程同步锁下的执行操作提取为方法，优化代码结构](https://github.com/Natsukage/PostNamazu/commit/5e1beebee4ec3200101822ea43a6aac94fe06896)
略