### PR TITLE
公开目标标记换成更底层的函数

### DIFF
--- a/PostNamazu/Actions/Mark.cs
+++ b/PostNamazu/Actions/Mark.cs
@@ -21,11 +21,11 @@ namespace PostNamazu.Actions
             //char __fastcall sub_1407A6A60(__int64 g_MarkingController, __int64 MarkType, __int64 ActorID)
             try
             {
-                MarkingFunc = SigScanner.ScanText("E8 * * * * 84 C0 74 ? 48 8B 06 48 8B CE FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? 33 C0 E9", nameof(MarkingFunc));
+                MarkingFunc = SigScanner.ScanText("E8 * * * * E8 ? ? ? ? 48 8B CB 48 89 86", nameof(MarkingFunc));
             }
             catch
             {
-                MarkingFunc = SigScanner.ScanText("48 89 5C 24 10 48 89 6C 24 18 57 48 83 EC 20 8D 42", nameof(MarkingFunc));
+                MarkingFunc = SigScanner.ScanText("48 89 5C 24 ? 57 48 83 EC ? 48 8B 0D ? ? ? ? 49 8B D8 8B FA E8 ? ? ? ? 48 85 C0", nameof(MarkingFunc));
             }
             LocalMarkingFunc = SigScanner.ScanText("E8 * * * * 4C 8B C5 8B D7 48 8B CB E8", nameof(LocalMarkingFunc)); //正确
             MarkingController = SigScanner.ScanText("48 8D 0D * * * * 4C 8B 85", nameof(MarkingController)); //正确
@@ -69,7 +69,7 @@ namespace PostNamazu.Actions
             ExecuteWithLock(() =>
             {
                 _ = !localOnly
-                    ? Memory.CallInjected64<char>(MarkingFunc, MarkingController, markingType, actor.ID)
+                    ? Memory.CallInjected64<char>(MarkingFunc, MarkingController, markingType - 1, actor.ID) //底层函数MarkingType从0开始，需要-1
                     : Memory.CallInjected64<char>(LocalMarkingFunc, MarkingController, markingType - 1, actor.ID, 0); //本地标点的markingType从0开始，因此需要-1
             });
         }

--- a/PostNamazu/Actions/Mark.cs
+++ b/PostNamazu/Actions/Mark.cs
@@ -68,9 +68,9 @@ namespace PostNamazu.Actions
             }
             ExecuteWithLock(() =>
             {
-                _ = !localOnly
-                    ? Memory.CallInjected64<char>(MarkingFunc, MarkingController, markingType - 1, actor.ID) //底层函数MarkingType从0开始，需要-1
-                    : Memory.CallInjected64<char>(LocalMarkingFunc, MarkingController, markingType - 1, actor.ID, 0); //本地标点的markingType从0开始，因此需要-1
+                Memory.CallInjected64<char>(LocalMarkingFunc, MarkingController, markingType - 1, actor.ID, 0); //本地标点的markingType从0开始，因此需要-1
+                if (!localOnly)
+                    Memory.CallInjected64<char>(MarkingFunc, MarkingController, markingType - 1, actor.ID); //模仿游戏函数，先执行本地再公开
             });
         }
 


### PR DESCRIPTION
Fix #84 
旨在解决一次性最多标记8个目标的限制。MarkingType同样从0开始，但为了兼容老版科技，并未修改定义本身。